### PR TITLE
TASK-3 - Make Signal Calculations Async.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ version = "0.1.0"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 clap = {version = "3.1.8", features = ["derive"]}
-yahoo_finance_api = { version = "1.1", features = ["blocking"] }
+yahoo_finance_api = { version = "1.1" }
 tokio = { version = "1.4.0", features = ["macros", "rt-multi-thread"] }
+async-trait = { version = "0.1.58" }

--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ Assignment was split in 3x tasks and 3x PRs for easy review:
 
 - [TASK-3](https://github.com/Sydney-o9/data-streaming/issues/5): Make Signal Calculations Async
      - See [PR - TASK-3](https://github.com/Sydney-o9/data-streaming/pull/6)
+
+Reviewer, you can review this PR from `develop` to `master`: 
+    - 👉 https://github.com/Sydney-o9/data-streaming/pull/7

--- a/README.md
+++ b/README.md
@@ -22,5 +22,17 @@ $ cargo run -- --from 2020-07-03T12:00:09Z --symbols LYFT,MSFT,AAPL,UBER,LYFT,FB
 
 ```bash
 $ cargo test
-
 ```
+
+### Assignment
+
+Assignment was split in 3x tasks and 3x PRs for easy review:
+
+- [TASK-1](https://github.com/Sydney-o9/data-streaming/issues/1): Finish what was started & implement all signal calculations
+     - See [PR - TASK-1](https://github.com/Sydney-o9/data-streaming/pull/2)
+
+- [TASK-2](https://github.com/Sydney-o9/data-streaming/issues/3): Implement Async Runtime
+     - See [PR - TASK-2](https://github.com/Sydney-o9/data-streaming/pull/4)
+
+- [TASK-3](https://github.com/Sydney-o9/data-streaming/issues/5): Make Signal Calculations Async
+     - See [PR - TASK-3](https://github.com/Sydney-o9/data-streaming/pull/6)


### PR DESCRIPTION
This Pull Request makes signal calculations Async and update tests to pass with async calls.

-----

- [x] Added async-trait crate to use async traits
- [x] Removed blocking feature of yahoo_finance_api crate
- [x] Changed fetch_closing_data to be async
- [x] Updated main to use now async fetch_closing_data
- [x] Updated AsyncStockSignal to be an async_trait by using the async_trait macro from the async-trait crate
- [x] Updated fn calculate of that trait to have an async signature
- [x] Updated all calculate implementations to be async as per updated trait AsyncStockSignal
- [x] Updated all tokio tests to use async calls

Work on #5.